### PR TITLE
절대경로 설정 jest config에도 설정

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,13 @@
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/src/$1",
+      "^@test/(.*)$": "<rootDir>/test/$1",
+      "^@call/(.*)$": "<rootDir>/call/$1"
+    },
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "preset": "ts-jest"
   }
 }


### PR DESCRIPTION
## Description
상대경로 축약하여 절대경로 설정시 오류가 나던 부분 조치하였습니다.
jest.config.js 가 아니라 package.json에 jest 설정이 있어 해당 부분 수정하였습니다.

<br>

## Key Changes
tsconfig 설정 뿐 아니라
jest config 설정도 해야한다고 합니다
```json
    // package.json
    "moduleNameMapper": {
      "^@/(.*)$": "<rootDir>/src/$1",
      "^@test/(.*)$": "<rootDir>/test/$1",
      "^@call/(.*)$": "<rootDir>/call/$1"
    },
```

<br>

## Issue Reference

> (Only on Fix and Hotfix branch)

## Package Change

> (Only on Chore branch)

<br>

## Checklist

- [ ] Asignee를 같은 파트원으로 지정했나요?
- [ ] Reviewer를 2명 이상 지정 했나요?
- [ ] 코드의 엣지 케이스에 대해 충분히 고민 하셨나요?
- [ ] conflict가 나지 않는지 확인 하셨나요?
